### PR TITLE
`Refactor fastifyRouter to use createFastifyRouter function`

### DIFF
--- a/src/router/fastifyRouter.ts
+++ b/src/router/fastifyRouter.ts
@@ -1,0 +1,138 @@
+import chalk from 'chalk';
+import { AppConfig } from '../core/AppConfigs';
+import fs from 'fs';
+import path from "path";
+import { TRouter } from '../types';
+import { getLogs } from '../utils';
+import { FastifyReply } from 'fastify/types/reply';
+import { FastifyError, FastifyRequest } from 'fastify';
+
+let uiPath: string;
+
+export const createFastifyRouter = (uiLocation: string) => {
+    uiPath = uiLocation;
+    return fastifyRouter;
+};
+
+/**
+* Sets up a Fastify router with authentication and logging routes.
+* @example
+* fastifyRouter({
+*   Username: "admin",
+*   Password: "admin",
+*   Secret: "mySecret"
+* });
+* Returns an async function to be used as a Fastify plugin.
+* @param {TRouter} {Username, Password, Secret} - Configuration object for setting username, password, and a secret for authentication.
+* @returns {Function} An async function that registers routes with Fastify.
+* @description
+*   - Ensures @fastify/static is installed for serving static files.
+*   - Defines routes for basic authentication and access to protected UI and audit log endpoints.
+*   - Sessions are managed using base64 encoding and cookie headers.
+*   - Fails gracefully if necessary modules are not present.
+*/
+const fastifyRouter = async ({ Username = "admin", Password = "admin", Secret }: TRouter) => {
+    let fastifyStatic;
+
+    try {
+        fastifyStatic = await import('@fastify/static');
+
+    } catch {
+        AppConfig.getAuditOption()?.logger?.info(
+            chalk.redBright("Please install @fastify/static to use the audit UI."),
+        );
+        return async () => { };
+    }
+
+    return async function (fastify: any, opts: any) {
+        await fastify.register(fastifyStatic.default, {
+            root: uiPath,
+            prefix: '/',
+        });
+
+        fastify.get('/auth-ui', (_: any, reply: FastifyReply) => {
+            reply.type('text/html').status(200).sendFile('auth.html');
+        });
+
+        fastify.post('/login', async (request: FastifyRequest<{ Body: { id: string; }; }>, reply: FastifyReply) => {
+            const { id } = request.body || {};
+
+            if (!id) {
+                reply.code(400).send({ message: "Missing id" });
+                return;
+            }
+
+            const decoded = Buffer.from(id, 'base64').toString('utf-8');
+            const [username, password] = decoded.split(':');
+
+            if (username !== Username) return reply.code(401).send({ message: "Invalid username" });
+            if (password !== Password) return reply.code(401).send({ message: "Invalid password" });
+
+            const session = Buffer.from(`${Username}:${Password}:${Secret}`).toString('base64');
+
+            reply.header('Set-Cookie', `session=${session}; HttpOnly; Path=/; SameSite=Strict; Max-Age=3600`);
+            reply.redirect(`/audit-ui`);
+        });
+
+        fastify.get('/audit-ui', (request: FastifyRequest, reply: FastifyReply) => {
+            const cookies = parseCookies(request.headers.cookie || "");
+            const session = cookies["session"];
+            if (!session) return reply.redirect('/auth-ui');
+            try {
+                const decoded = Buffer.from(session, 'base64').toString('utf-8');
+                const [username, password, secret] = decoded.split(':');
+
+                if (username !== Username || password !== Password || secret !== Secret) {
+                    return reply.redirect('/auth-ui');
+                }
+
+                reply.header('Set-Cookie', `session=${session}; HttpOnly; Path=/; SameSite=Strict; Max-Age=3600`);
+                reply.type('text/html').sendFile('index.html');
+            } catch {
+                return reply.redirect('/auth-ui');
+            }
+        });
+
+        fastify.get('/audit-log', async (request: FastifyRequest, reply: FastifyReply) => {
+            const cookies = parseCookies(request.headers.cookie || "");
+            const session = cookies["session"];
+            if (!session) return reply.code(403).send("Forbidden");
+
+            try {
+                const decoded = Buffer.from(session, 'base64').toString('utf-8');
+                const [username, password, secret] = decoded.split(':');
+
+                if (username !== Username || password !== Password || secret !== Secret) {
+                    return reply.code(403).send("Forbidden");
+                }
+
+                const logs = await getLogs();
+                reply.send({ logs });
+            } catch {
+                return reply.code(403).send("Forbidden");
+            }
+        });
+    };
+};
+
+
+
+/**
+* Parses a cookie header string into an object of key-value pairs.
+* @example
+* parseCookies("key1=value1; key2=value2")
+* Returns: { key1: "value1", key2: "value2" }
+* @param {string} cookieHeader - A string representing the cookie header with cookies separated by semicolons.
+* @returns {Record<string, string>} An object containing the parsed cookies as key-value pairs.
+* @description
+*   - Each cookie is expected to be in the format "key=value".
+*   - Values are decoded using decodeURIComponent.
+*   - Trims whitespace and processes each segment.
+*/
+const parseCookies = (cookieHeader: string): Record<string, string> => {
+    return cookieHeader.split(';').reduce((acc: any, cookie) => {
+        const [key, value] = cookie.trim().split('=');
+        acc[key] = decodeURIComponent(value);
+        return acc;
+    }, {});
+};

--- a/src/router/router.ts
+++ b/src/router/router.ts
@@ -8,6 +8,7 @@ import { AppConfig } from "../core/AppConfigs";
 import { checkForModule } from "../utils";
 import { createKoaRouter } from "./koaRouter";
 import { TRouter } from "../types";
+import { createFastifyRouter } from "./fastifyRouter";
 
 
 const __filename = fileURLToPath(import.meta.url);
@@ -167,57 +168,8 @@ const expressRouter = async ({ Username = "admin", Password = "admin", Secret }:
     return router;
 };
 
-/**
- * Asynchronously creates a Fastify plugin for serving static files and API endpoints.
- *
- * This function attempts to dynamically import the `@fastify/static` module. If the import fails,
- * it returns a no-op async function. Otherwise, it returns an async function that registers the static
- * file handler and sets up two routes:
- * 
- * - `/audit-ui`: Serves the `index.html` file as an HTML response.
- * - `/audit-log`: Returns audit logs as a JSON object.
- *
- * @returns {Promise<(fastify: any, opts: any) => Promise<void>>} A promise that resolves to a Fastify plugin function.
- */
-const fastifyRouter = async () => {
-
-    let fastifyStatic;
-    try {
-        fastifyStatic = await import('@fastify/static');
-    } catch {
-        return async () => { };
-    }
-
-    return async function (fastify: any, opts: any) {
-        await fastify.register(fastifyStatic.default, {
-            root: uiPath,
-            prefix: '/',
-        });
-
-        /**
-                * Sends an HTML file as the response for the '/audit-ui' route in Fastify.
-                * @example
-                * (_req, reply) => {
-                *   reply.type('text/html').sendFile('index.html');
-                * }
-                * @param {any} _ - The incoming request object (not used in this function).
-                * @param {any} reply - The Fastify reply object used to send responses.
-                * @description
-                *   - This function sets the response type to 'text/html'.
-                *   - It sends 'index.html' located in the static files directory specified in uiPath.
-                */
-        fastify.get('/audit-ui', (_: any, reply: any) => {
-            reply.type('text/html').sendFile('index.html');
-        });
-
-        fastify.get('/audit-log', (_: any, reply: any) => {
-            reply.send({ logs: getLogs() });
-        });
-    };
-};
-
 const koaRouter = createKoaRouter(uiPath);
-
+const fastifyRouter = createFastifyRouter(uiPath);
 
 export const checkForFramework = () => {
     const activeFramework = AppConfig.getFramework() as string;


### PR DESCRIPTION
## 🔐 Implement Auth System for Audit UI and Log Access

### ✨ Summary

This pull request introduces an authentication layer to protect access to both the audit dashboard (`/audit-ui`) and log data (`/audit-log`) in the Fastify version of the server.

### ✅ What’s Added

- Integrated a cookie-based auth system without installing any new dependencies.
- Secured the audit UI and log API endpoints to require valid authentication.
- Session token now stored in cookies instead of query parameters (more secure and clean).
- Session expiration configured to **1 hour**.

### 🛠️ Refactoring

- Improved route structure and separation of responsibilities for cleaner logic.
- Unified session handling across both UI and API routes.
- Type-safe improvements for `request.body` and cookie parsing using built-in Fastify utilities.

### 🔐 Security Improvements
- Switched from URL-based auth to secure, time-bound cookie-based sessions.
- No external packages used — full auth handled with native Fastify and Node capabilities.

### Setup

```ts
import Fastify from 'fastify';
import { Auditor } from "@kingdiablo/auditor";

const fastify = Fastify();

// Initialize Auditor with Fastify support and UI enabled
const auditor = new Auditor({
    framework: "fastify",
    destinations: ["file"],
    useUI: true,
    maxRetention: 1
});

await auditor.Setup();

// Basic route
fastify.get('/', async (_request, _reply) => {
    return { message: 'Hello from Fastify' };
});

// Attach request and response logging hooks
fastify.addHook("onRequest", auditor.RequestLogger().onRequest);
fastify.addHook("onResponse", auditor.RequestLogger().onResponse);

// Register the Audit UI, secured by a generated secret
const router = auditor.CreateUI();
fastify.register(await router({ Secret: crypto.randomUUID() }));

// Setup centralized error logging
fastify.setErrorHandler(auditor.ErrorLogger());

// Start the server
fastify.listen({ port: 9000 }, (err, address) => {
    if (err) {
        console.error(err);
        process.exit(1);
    }
    console.log(`🚀 Server running at http://localhost:9000`);
});
```