### PR TITLE
Feat/UI relocation

### DIFF
--- a/builder.ts
+++ b/builder.ts
@@ -7,5 +7,5 @@ rmSync('dist', { recursive: true, force: true });
 // Run tsup
 execSync('tsup', { stdio: 'inherit' });
 
-// Copy UI folder
-cpSync('src/ui', 'dist/ui', { recursive: true });
+// Copy UI folder (this is now deprecated as of version 0.3.1^)
+// cpSync('src/ui', 'dist/ui', { recursive: true }); 

--- a/src/core/Auditor.ts
+++ b/src/core/Auditor.ts
@@ -2,7 +2,7 @@ import chalk from "chalk";
 import { auditModel, checkForMongodb } from "../database/mongodb";
 import { auditPrisma, checkForPrisma } from "../database/prisma";
 import { errorLogger, requestLogger } from "../middleware";
-import { UIRouter, checkForFramework, downloadDependency } from "../router";
+import { UIRouter, checkForFramework, deleteDownloadedDependency, downloadDependency } from "../router";
 import { DBInstance, Framework, SupportedLoggersRequest, TAuditOptions, TEvent, TFileConfig, TRemoteConfig } from "../types/type";
 import { createFile, generateAuditContent, generateByte, getFileLocation, handleLog, handleLogRotation } from "../utils";
 import { addTask, beginSchedule, currentTimer } from "../utils/scheduler";
@@ -140,7 +140,7 @@ export class Audit<F extends Framework = "express"> {
                 AppConfig.getAuditOption()?.logger?.info(chalk.yellow("In order to use this module some dependency will be downloaded"));
                 await downloadDependency();
             }
-        }
+        } else await deleteDownloadedDependency();
 
 
 

--- a/src/router/expressRouter.ts
+++ b/src/router/expressRouter.ts
@@ -64,9 +64,9 @@ const expressRouter = async ({ Username = "admin", Password = "admin", Secret }:
 
         res.cookie('session', credentials, {
             httpOnly: true,
-            secure: false, // set to false in dev if not using HTTPS
+            secure: false,         
             sameSite: 'Strict',
-            maxAge: '3600',
+            maxAge: 3600 * 1000,
         });
 
         return res.redirect(303, `/audit-ui`);
@@ -98,6 +98,13 @@ const expressRouter = async ({ Username = "admin", Password = "admin", Secret }:
         if (username != Username) return res.redirect(303, "/auth-ui");
         if (password != Password) return res.redirect(303, "/auth-ui");
         if (secret != Secret) return res.redirect(303, "/auth-ui");
+
+        res.cookie('session', session, {
+            httpOnly: true,
+            secure: false,
+            sameSite: 'Strict',
+            maxAge: 3600 * 1000,
+        });
 
 
         res.statusMessage = "Fetched audit UI";

--- a/src/router/router.ts
+++ b/src/router/router.ts
@@ -1,6 +1,6 @@
 import chalk from "chalk";
 import { constants, createWriteStream } from "fs";
-import { access, mkdir } from "fs/promises";
+import { access, mkdir, rm } from "fs/promises";
 import path from "path";
 import { Readable } from 'stream';
 import { pipeline } from 'stream/promises';
@@ -10,7 +10,6 @@ import { checkForModule } from "../utils";
 import { createExpressRouter } from "./expressRouter";
 import { createFastifyRouter } from "./fastifyRouter";
 import { createKoaRouter } from "./koaRouter";
-import { rm } from "fs/promises";
 
 
 


### PR DESCRIPTION
## 🧹 Refactor: Remove Bundled UI Assets and Introduce On-Demand Installer

### Overview

This PR unbundles the ui assets (HTML, CSS, JS, Chart.js, etc.) in the default installation of the `@kingdiablo/auditor` package.

---

### ✅ Changes Implemented

- 🚫 **Removed** embedded UI assets from the core package
- 📁 UI files are no longer stored locally rather they are fetched when `useUI: true`
- 🧽 If the user sets `useUI: false` in the constructor and UI files exist, **they will be deleted automatically**

---

### 💡 Motivation

Previously, the package shipped with full UI assets by default, which resulted in:

- UI files being present even when not used

With this update, the package remains **lean by default**, and only pulls in the UI when explicitly enabled.

---

### 🧪 How to Use

```ts
import { Auditor } from "@kingdiablo/auditor";

// Enable the dashboard UI (downloads UI files at runtime)
const auditor = new Auditor({
  framework: "express",
  destinations: ["file"],
  useUI: true, // UI will be downloaded and served
});

To remove the UI files:

```ts
const auditor = new Auditor({
  framework: "express",
  destinations: ["file"],
  useUI: false, // Will delete UI files if previously downloaded
});
```

---

### 📦 Benefits

* 🪶 **Reduced base install size**
* ⚙️ UI is now optional and modular — cleaner dependency separation
* 🧼 Automatic cleanup for environments that no longer need the UI

---

### 📝 Notes
* This change **does not affect core auditing functionality**
* Future versions may allow mirror URLs or custom UI overrides
---

Closes: #11
